### PR TITLE
Remove requirement to have gearman executable in path

### DIFF
--- a/islandora_job.install
+++ b/islandora_job.install
@@ -39,7 +39,7 @@ function islandora_job_requirements($phase) {
     }
     else {
       $requirements['gearman_executable']['description'] = $t("Gearman executable is not in PATH.");
-      $requirements['gearman_executable']['severity'] = REQUIREMENT_ERROR;
+      $requirements['gearman_executable']['severity'] = REQUIREMENT_INFO;
     }
   }
 


### PR DESCRIPTION
If this code is being run a web server it isn't necessary that gearman be on the path of the web server. An example configuration: 

- *webserver*
  - has gearman php extension
  - has this module installed to intercept derivative hooks (its a transitive dependancy from islandora_job_derivative)
  - does not have gearman executable on path because it never needs it
- *derivative server*
  - has gearman php extension
  - has module
  - has gearman executable

In this sort of configuration the module won't install on the web server, even though it never needs the gearman executable. 