### PR TITLE
Add multisite support

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -28,5 +28,11 @@ function islandora_job_admin_form($form, &$form_state) {
     '#required' => TRUE,
     '#default_value' => variable_get('islandora_job_server_port', 4730),
   );
+  $form['islandora_job_multisite_prefix'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable multisite prefix'),
+    '#description' => t('Add a multisite prefix to job queue name'),
+    '#default_value' => variable_get('islandora_job_multisite_prefix', FALSE),
+  );
   return system_settings_form($form);
 }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -35,7 +35,7 @@ function islandora_job_function_name($job_name) {
   // Chop the 'sites/' part of the path off. This gives you the name of the
   // site dir for the multisite, for example sites/example would be example
   // we use this to create the queue for this multisite.
-  $site = substr(conf_path(),6);
+  $site = substr(conf_path(), 6);
   return $site == 'default' ? $job_name : "{$site}_{$job_name}";
 }
 

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -20,6 +20,26 @@ function islandora_job_get_client() {
 }
 
 /**
+ * Get job function name.
+ *
+ * This function allows support for multisites by adding the site
+ * name to each job function.
+ *
+ * @param string $job_name
+ *   Name of the job without site.
+ *
+ * @return string
+ *   Job name with site added.
+ */
+function islandora_job_function_name($job_name) {
+  // Chop the 'sites/' part of the path off. This gives you the name of the
+  // site dir for the multisite, for example sites/example would be example
+  // we use this to create the queue for this multisite.
+  $site = substr(conf_path(),6);
+  return $site == 'default' ? $job_name : "{$site}_{$job_name}";
+}
+
+/**
  * Constructs a payload from arguments passed to various API functions.
  *
  * @param string $job_name
@@ -32,11 +52,15 @@ function islandora_job_get_client() {
  *   A JSON encoded payload for Gearman.
  */
 function islandora_job_format_payload($job_name, $args) {
+  global $user;
+  global $base_url;
   array_shift($args);
   return json_encode(
     array(
       "func" => $job_name,
       "args" => $args,
+      "site" => $base_url,
+      "uid" => $user->uid,
     )
   );
 }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -36,7 +36,13 @@ function islandora_job_function_name($job_name) {
   // site dir for the multisite, for example sites/example would be example
   // we use this to create the queue for this multisite.
   $site = substr(conf_path(), 6);
-  return $site == 'default' ? $job_name : "{$site}_{$job_name}";
+
+  if ($site == 'default' || !variable_get('islandora_job_multisite_prefix', FALSE)) {
+    return $job_name;
+  }
+  else {
+    return "{$site}_{$job_name}";
+  }
 }
 
 /**

--- a/islandora_job.module
+++ b/islandora_job.module
@@ -38,7 +38,7 @@ function islandora_job_submit($job_name) {
   module_load_include('inc', 'islandora_job', 'includes/utilities');
   $payload = islandora_job_format_payload($job_name, func_get_args());
   $client = islandora_job_get_client();
-  return $client->doNormal($job_name, $payload);
+  return $client->doNormal(islandora_job_function_name($job_name), $payload);
 }
 
 /**
@@ -58,7 +58,7 @@ function islandora_job_submit_background($job_name) {
   module_load_include('inc', 'islandora_job', 'includes/utilities');
   $payload = islandora_job_format_payload($job_name, func_get_args());
   $client = islandora_job_get_client();
-  return $client->doBackground($job_name, $payload);
+  return $client->doBackground(islandora_job_function_name($job_name), $payload);
 }
 
 /**
@@ -92,7 +92,7 @@ function islandora_job_submit_batch($tasks, $callback = NULL) {
     // Push on a dummy arg as if this array came from func_get_args().
     array_unshift($args, '');
     $payload = islandora_job_format_payload($job_name, $args);
-    $client->addTask($job_name, $payload);
+    $client->addTask(islandora_job_function_name($job_name), $payload);
   }
   return $client->runTasks();
 }


### PR DESCRIPTION
This PR adds the name of the site to the job name when being submitted to gearman. The name of the site isn't included when you are submitting jobs to the default site. 

For example if your site structure is: 
- sites/default 
- sites/lyrasis
- sites/razzard_inc

If you submitted the job: `islandora_do_work` on each site, the jobs would be queued in gearman as:
- `islandora_do_work`
- `lyrasis_islandora_do_work`
- `razzard_inc_islandora_do_work`

Two more parameters are added to the JSON that is passed to the worker function: 
- `site`
- `uid`

If running `islandora_job` on a default drupal site, this patch should be transparent and `islandora_job` and `gearman_init` should continue to work as before.

However these new variables can be used in a multisite context to:
- ensure that drush is called on the correct multisite
- to actually do the work on the object as the user that submitted the request

An example of a worker process to use the extra arguments on a multisite can be found here: 
https://github.com/jonathangreen/german-worker